### PR TITLE
fix: Update GenericRule.fields to match usage in code

### DIFF
--- a/bids-validator/src/schema/applyRules.ts
+++ b/bids-validator/src/schema/applyRules.ts
@@ -164,7 +164,6 @@ function evalAdditionalColumns(rule: GenericRule, context: BIDSContext): void {
  *
  */
 function evalJsonCheck(rule: GenericRule, context: BIDSContext): void {
-  // @ts-expect-error
   for (const [key, requirement] of Object.entries(rule.fields)) {
     const severity = getFieldSeverity(requirement, context)
     if (severity && severity !== 'ignore' && !(key in context.sidecar)) {

--- a/bids-validator/src/types/schema.ts
+++ b/bids-validator/src/types/schema.ts
@@ -30,7 +30,7 @@ export interface GenericRule {
   columns?: Record<string, string>
   additional_columns?: string
   initial_columns?: string[]
-  fields?: Record<string, string | SchemaFields>
+  fields: Record<string, SchemaFields>
   issue?: SchemaIssue
 }
 


### PR DESCRIPTION
Simplifying this and not allowing the field to be undefined resolves a number of type issues.