### PR TITLE
Workaround for Next.js updates to resolve bids-validator monorepo package

### DIFF
--- a/bids-validator-web/components/App.jsx
+++ b/bids-validator-web/components/App.jsx
@@ -3,7 +3,7 @@ import bowser from 'bowser'
 import Issues from '../components/Issues'
 import BrowserWarning from './BrowserWarning'
 import Validate from '../components/Validate'
-import validate from 'bids-validator'
+import validate from '../../bids-validator'
 import validatorPackageJson from 'bids-validator/package.json' assert { type: 'json' }
 const version = validatorPackageJson.version
 


### PR DESCRIPTION
@rwblair I think this should fix this enough to use for now. Seems to work in Chrome and Firefox with this unless I'm missing something.